### PR TITLE
refactor `HasMiddleware` trait

### DIFF
--- a/src/handler.rs
+++ b/src/handler.rs
@@ -1,13 +1,25 @@
 use std::result::Result;
 
 use lambda_http::{Body, Request, Response};
+use lambda_runtime::error::HandlerError;
 
 use crate::error;
-use crate::middleware::HasMiddleware;
 
 type LambdaResponse = Response<Body>;
 
 type HandlerResult<E = error::Error> = Result<LambdaResponse, E>;
+
+/// A trait which provides a method for handling requests.
+pub trait Handle {
+    /// Handles a request.
+    fn handle(self, req: Request) -> Result<LambdaResponse, HandlerError>;
+}
+
+/// A trait which provides a method for wrapping handlers with middleware.
+pub trait WrapWith<E>: Handle {
+    /// Wraps a handler with the provided middleware, returning a new handler.
+    fn wrap_with<M: Fn(Handler<E>) -> Handler<E>>(self, middleware: M) -> Handler<E>;
+}
 
 /// A type alias for handler functions.
 ///
@@ -16,7 +28,21 @@ type HandlerResult<E = error::Error> = Result<LambdaResponse, E>;
 /// of the box, such as Serde JSON errors.
 pub type Handler<E = error::Error> = Box<dyn Fn(Request) -> HandlerResult<E>>;
 
-impl<E> HasMiddleware<E> for Handler<E> {
+impl<E> Handle for Handler<E>
+where
+    E: 'static + Sync + Send + failure::Fail + From<failure::Error>,
+{
+    /// Handles a request, returning a `HandlerResult`. Any errors will be mapped to a
+    /// `failure::Error`.
+    fn handle(self, req: Request) -> Result<LambdaResponse, HandlerError> {
+        Ok(self(req).map_err(|e| -> failure::Error { e.into() })?)
+    }
+}
+
+impl<E> WrapWith<E> for Handler<E>
+where
+    E: 'static + Sync + Send + failure::Fail + From<failure::Error>,
+{
     fn wrap_with<M: Fn(Handler<E>) -> Handler<E>>(self, middleware: M) -> Handler<E> {
         middleware(self)
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -52,14 +52,12 @@
 //! To illustrate, let's examine an example that utilizes our middleware above.
 //!
 //! ```
-//! use failure;
 //! use lambda_http::{lambda, IntoResponse, Request};
 //! use lambda_runtime::{error::HandlerError, Context};
-//! use vicuna::{default_handler, HasMiddleware};
+//! use vicuna::{default_handler, Handle, WrapWith};
 //!
 //! fn hello_lambda(req: Request, _: Context) -> Result<impl IntoResponse, HandlerError> {
-//!     let handler = default_handler().wrap_with(add_header);
-//!     Ok(handler(req).map_err(|e| -> failure::Error { e.into() })?)
+//!     default_handler().wrap_with(add_header).handle(req)
 //! }
 //!
 //! fn main() {
@@ -80,8 +78,8 @@
 //! [`lambda_runtime`]: ../lambda_runtime/index.html
 //! [`serverless-rust`]: https://github.com/softprops/serverless-rust
 
-pub use handler::{default_handler, Handler};
-pub use middleware::{HasMiddleware, Middleware};
+pub use handler::{default_handler, Handle, Handler, WrapWith};
+pub use middleware::Middleware;
 
 pub use lambda_http;
 pub use lambda_runtime;

--- a/src/middleware.rs
+++ b/src/middleware.rs
@@ -1,11 +1,5 @@
-use crate::handler::Handler;
 use crate::error;
+use crate::handler::Handler;
 
 /// Middleware type alias.
 pub type Middleware<E = error::Error> = Box<dyn Fn(Handler<E>) -> Handler<E>>;
-
-/// A trait which enables wrapping of middleware around the handler.
-pub trait HasMiddleware<E> {
-    /// Wraps a handler with the provided middleware, returning a new handler.
-    fn wrap_with<M: Fn(Handler<E>) -> Handler<E>>(self, middleware: M) -> Handler<E>;
-}


### PR DESCRIPTION
This patch refactors and removes the `HasMiddleware` trait. Instead,
we're left with two new traits, `Handle` and `WrapWith`. The former
exposes a new method, `handle`, which is a convenience method for
handling requests and abstracts away the need to map errors manually.
The latter is a re-naming of `HasMiddleware` to a perhaps more idiomatic
convention.

Note that this is a breaking change since `HasMiddleware` is removed
entirely.