### PR TITLE
pass context through middleware

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,16 +58,16 @@ Middleware are wrapped around handlers, which themselves produce a handler for
 chainable invocation:
 
 ```rust
-use lambda_http::{lambda, IntoResponse, Request, Response};
+use lambda_http::{lambda, IntoResponse, Request};
 use lambda_runtime::{error::HandlerError, Context};
 use vicuna::{Handle, WrapWith};
 
-fn hello_lambda(req: Request, _: Context) -> Result<impl IntoResponse, HandlerError> {
+fn hello_lambda(req: Request, context: Context) -> Result<impl IntoResponse, HandlerError> {
     // Middleware is applied in reverse order!
-    let handler = default_handler()
+    default_handler()
         .wrap_with(say_hello)
         .wrap_with(add_header)
-        .handle(req);
+        .handle(req, context)
 }
 
 fn main() {

--- a/src/handler.rs
+++ b/src/handler.rs
@@ -1,32 +1,26 @@
 use std::result::Result;
 
 use lambda_http::{Body, Request, Response};
-use lambda_runtime::error::HandlerError;
+use lambda_runtime::{error::HandlerError, Context};
 
 use crate::error;
 
 type LambdaResponse = Response<Body>;
 
-type HandlerResult<E = error::Error> = Result<LambdaResponse, E>;
-
-/// A trait which provides a method for handling requests.
-pub trait Handle {
-    /// Handles a request.
-    fn handle(self, req: Request) -> Result<LambdaResponse, HandlerError>;
-}
-
-/// A trait which provides a method for wrapping handlers with middleware.
-pub trait WrapWith<E>: Handle {
-    /// Wraps a handler with the provided middleware, returning a new handler.
-    fn wrap_with<M: Fn(Handler<E>) -> Handler<E>>(self, middleware: M) -> Handler<E>;
-}
+type HandlerResult<E> = Result<LambdaResponse, E>;
 
 /// A type alias for handler functions.
 ///
 /// While a default error type is provided, callers may provide their own alternative. This is
 /// particularly important when your application deals with error types that are not supported out
 /// of the box, such as Serde JSON errors.
-pub type Handler<E = error::Error> = Box<dyn Fn(Request) -> HandlerResult<E>>;
+pub type Handler<E = error::Error> = Box<dyn Fn(Request, Context) -> HandlerResult<E>>;
+
+/// A trait which provides a method for handling requests.
+pub trait Handle {
+    /// Handles a request.
+    fn handle(self, request: Request, context: Context) -> Result<LambdaResponse, HandlerError>;
+}
 
 impl<E> Handle for Handler<E>
 where
@@ -34,9 +28,15 @@ where
 {
     /// Handles a request, returning a `HandlerResult`. Any errors will be mapped to a
     /// `failure::Error`.
-    fn handle(self, req: Request) -> Result<LambdaResponse, HandlerError> {
-        Ok(self(req).map_err(|e| -> failure::Error { e.into() })?)
+    fn handle(self, request: Request, context: Context) -> Result<LambdaResponse, HandlerError> {
+        Ok(self(request, context).map_err(|e| -> failure::Error { e.into() })?)
     }
+}
+
+/// A trait which provides a method for wrapping handlers with middleware.
+pub trait WrapWith<E>: Handle {
+    /// Wraps a handler with the provided middleware, returning a new handler.
+    fn wrap_with<M: Fn(Handler<E>) -> Handler<E>>(self, middleware: M) -> Handler<E>;
 }
 
 impl<E> WrapWith<E> for Handler<E>
@@ -53,5 +53,5 @@ where
 /// This is often useful as the beginning of a handler which will be wrapped
 /// with middleware.
 pub fn default_handler<E>() -> Handler<E> {
-    Box::new(|_| Ok(Response::default()))
+    Box::new(|_, _| Ok(Response::default()))
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -28,9 +28,9 @@
 //! use vicuna::Handler;
 //!
 //! fn add_header(handler: Handler) -> Handler {
-//!     Box::new(move |req| {
+//!     Box::new(move |req, ctx| {
 //!         // Resolve any upstream middleware into a response.
-//!         let mut resp = handler(req)?;
+//!         let mut resp = handler(req, ctx)?;
 //!         // Add our custom header to the response.
 //!         resp.headers_mut().insert(
 //!             HeaderName::from_static("x-hello"),
@@ -56,8 +56,8 @@
 //! use lambda_runtime::{error::HandlerError, Context};
 //! use vicuna::{default_handler, Handle, WrapWith};
 //!
-//! fn hello_lambda(req: Request, _: Context) -> Result<impl IntoResponse, HandlerError> {
-//!     default_handler().wrap_with(add_header).handle(req)
+//! fn hello_lambda(req: Request, ctx: Context) -> Result<impl IntoResponse, HandlerError> {
+//!     default_handler().wrap_with(add_header).handle(req, ctx)
 //! }
 //!
 //! fn main() {


### PR DESCRIPTION
This patch extends the middleware interface to pass through the request
context provided by the Lambda runtime.

Note that this is a breaking change.