### PR TITLE
provide basic middleware

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,23 +20,17 @@
 //!
 //! ## Examples
 //!
-//! To make this more concrete, let's explore a simple middleware which will add a header to our
-//! response.
+//! To make this more concrete, let's demonstrate what the structure of middleware looks like.
 //!
-//! ```
-//! use lambda_http::http::header::{HeaderName, HeaderValue};
+//! ```rust,no_run
 //! use vicuna::Handler;
 //!
-//! fn add_header(handler: Handler) -> Handler {
+//! fn my_middleware(handler: Handler) -> Handler {
 //!     Box::new(move |request, context| {
-//!         // Resolve any upstream middleware into a response.
-//!         let mut resp = handler(request, context)?;
-//!         // Add our custom header to the response.
-//!         resp.headers_mut().insert(
-//!             HeaderName::from_static("x-hello"),
-//!             HeaderValue::from_static("world"),
-//!         );
-//!         Ok(resp)
+//!         // Resolve upstream middleware chain into a response...
+//!         let mut response = handler(request, context);
+//!         // ...mutate response as desired.
+//!         response
 //!     })
 //! }
 //! ```
@@ -49,29 +43,21 @@
 //! convenience and can be used to start a chain of middleware. Once the chain is established, we
 //! are ready to provide it as a handler to the `lambda_runtime` framework via the [`lambda!`] macro.
 //!
-//! To illustrate, let's examine an example that utilizes our middleware above.
+//! To illustrate, let's examine an example that utilizes builtin middleware.
 //!
 //! ```rust,no_run
-//! use lambda_http::{
-//!    http::header::{HeaderName, HeaderValue},
-//!    lambda,
+//! use vicuna::{
+//!     default_handler,
+//!     error,
+//!     lambda_http::lambda,
+//!     middleware::{body, header},
+//!     Handler, WrappingHandler,
 //! };
-//! use vicuna::{default_handler, Handler, WrappingHandler};
 //!
-//! fn add_header(handler: Handler) -> Handler {
-//!     Box::new(move |request, context| {
-//!         // Resolve any upstream middleware into a response.
-//!         let mut resp = handler(request, context)?;
-//!         // Add our custom header to the response.
-//!         resp.headers_mut().insert(
-//!             HeaderName::from_static("x-hello"),
-//!             HeaderValue::from_static("world"),
-//!         );
-//!         Ok(resp)
-//!     })
-//! }
-//!
-//! lambda!(default_handler().wrap_with(add_header).handler())
+//! lambda!(default_handler::<error::Error>()
+//!     .wrap_with(body("Hello, world!"))
+//!     .wrap_with(header("x-foo", "bar"))
+//!     .handler())
 //! ```
 //!
 //! This is a simple example that demonstrates how straightforward it is to establish an AWS Lambda

--- a/src/middleware.rs
+++ b/src/middleware.rs
@@ -1,5 +1,102 @@
-use crate::error;
-use crate::handler::Handler;
+use lambda_http::{
+    http::{
+        header::{HeaderValue, IntoHeaderName},
+        StatusCode,
+    },
+    Body,
+};
+
+use crate::{error, handler::Handler};
 
 /// Middleware type alias.
 pub type Middleware<E = error::Error> = Box<dyn Fn(Handler<E>) -> Handler<E>>;
+
+/// Adds the given header name and value to the response.
+pub fn header<E: 'static, N, V>(header_name: N, header_value: V) -> Middleware<E>
+where
+    N: IntoHeaderName + Copy + 'static,
+    V: Into<String> + Copy + 'static,
+{
+    Box::new(move |handler| {
+        Box::new(move |request, context| {
+            let mut response = handler(request, context)?;
+            if let Ok(value) = HeaderValue::from_str(header_value.into().as_str()) {
+                response.headers_mut().insert(header_name, value);
+            }
+            Ok(response)
+        })
+    })
+}
+
+/// Alters the status code of the response.
+pub fn status<E: 'static>(code: StatusCode) -> Middleware<E> {
+    Box::new(move |handler| {
+        Box::new(move |request, context| {
+            let mut response = handler(request, context)?;
+            *response.status_mut() = code;
+            Ok(response)
+        })
+    })
+}
+
+/// Alters the body of the response.
+pub fn body<E: 'static, B>(body: B) -> Middleware<E>
+where
+    B: Into<Body> + Copy + 'static,
+{
+    Box::new(move |handler| {
+        Box::new(move |request, context| {
+            let mut response = handler(request, context)?;
+            *response.body_mut() = body.into();
+            Ok(response)
+        })
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use std::fmt::Debug;
+
+    use lambda_http::{http::StatusCode, Body, Request, Response};
+    use lambda_runtime::Context;
+
+    use crate::handler::{default_handler, WrappingHandler};
+
+    use super::*;
+
+    fn handler_resp<E: Debug>(handler: Handler<E>) -> Response<Body> {
+        let request = Request::default();
+        let context = Context::default();
+        handler(request, context).unwrap()
+    }
+
+    #[test]
+    fn test_header() {
+        let handler = default_handler::<error::Error>()
+            .wrap_with(header("x-foo", "bar"))
+            .handler();
+        let resp = handler_resp(handler);
+        assert_eq!(
+            resp.headers().get("x-foo"),
+            Some(&HeaderValue::from_static("bar"))
+        );
+    }
+
+    #[test]
+    fn test_status() {
+        let handler = default_handler::<error::Error>()
+            .wrap_with(status(StatusCode::CREATED))
+            .handler();
+        let resp = handler_resp(handler);
+        assert_eq!(resp.status(), StatusCode::CREATED);
+    }
+
+    #[test]
+    fn test_body() {
+        let handler = default_handler::<error::Error>()
+            .wrap_with(body("foo"))
+            .handler();
+        let resp = handler_resp(handler);
+        assert_eq!(*resp.body(), Body::Text("foo".to_string()));
+    }
+}


### PR DESCRIPTION
This patch adds a few basic middleware that extend responses by adding
in various features, such as headers or bodies.